### PR TITLE
modify: 情報投稿ページ（newとedit）に移動したときに場所の検索ができない不具合修正

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -3,7 +3,6 @@
 // a relevant structure within app/javascript and only use these pack files to reference
 // that code so it'll be compiled.
 
-require("@rails/ujs").start()
 require("turbolinks").start()
 require("@rails/activestorage").start()
 require("channels")

--- a/app/javascript/packs/map_new_post.js
+++ b/app/javascript/packs/map_new_post.js
@@ -6,11 +6,7 @@ let geocoder;
 let marker;
 let hasMarker = false;
 
-const searchLocationBtn = document.getElementById('search-location-btn')
-const locationButton = document.getElementById("current_location");
-
 function initNewPostMap() {
-
   function succeedGetCurrentPosition(position) {
     const pos = new google.maps.LatLng(
       position.coords.latitude,
@@ -77,6 +73,33 @@ function initNewPostMap() {
 
   geocoder = new google.maps.Geocoder()
   navigator.geolocation.getCurrentPosition(succeedGetCurrentPosition, failGetCurrentPosition);
+
+  const searchLocationBtn = document.getElementById('search-location-btn')
+  const locationBtn = document.getElementById("current_location");
+  // 現在地ボタンのイベント設定
+  locationBtn.addEventListener("click", moveCurrentLocation);
+  // 検索ボタンのイベント設定
+  searchLocationBtn.addEventListener("click", () => {
+    const inputAddress = document.getElementById('placeSearch').value;
+    geocoder.geocode( { 'address': inputAddress}, function(results, status) {
+      if (status == 'OK') {
+        // マーカーが複数できないようにする
+        if (hasMarker === true){
+          resetMarker();
+        }
+        //新しくマーカーを作成する
+        window.map.setCenter(results[0].geometry.location);
+        marker = placeMarker(results[0].geometry.location);
+        hasMarker = true;
+
+        //検索した時に緯度経度を入力する
+        inputLatLng(results[0].geometry.location);
+        inputPrefRegionPlaceId(results[0].geometry.location, geocoder);
+      } else {
+        alert('該当する結果がありませんでした：' + status);
+      }
+    });
+  });
 }
 
 // 現在地への移動
@@ -117,31 +140,8 @@ function handleLocationError(browserHasGeolocation, infoWindow, pos) {
   infoWindow.open(map);
 }
 
-window.onload = function() {
-  inputRegion();
-  // 現在地ボタンのイベント設定
-  locationButton.addEventListener("click", moveCurrentLocation);
-  // 検索ボタンのイベント設定
-  searchLocationBtn.addEventListener("click", () => {
-    const inputAddress = document.getElementById('placeSearch').value;
-    geocoder.geocode( { 'address': inputAddress}, function(results, status) {
-      if (status == 'OK') {
-        // マーカーが複数できないようにする
-        if (hasMarker === true){
-          resetMarker();
-        }
-        //新しくマーカーを作成する
-        window.map.setCenter(results[0].geometry.location);
-        marker = placeMarker(results[0].geometry.location)
-        hasMarker = true;
-
-        //検索した時に緯度経度を入力する
-        inputLatLng(results[0].geometry.location);
-        inputPrefRegionPlaceId(results[0].geometry.location, geocoder)
-      } else {
-        alert('該当する結果がありませんでした：' + status);
-      }
-    });
-  });
-}
 window.initMap = initNewPostMap;
+
+document.addEventListener('turbolinks:load', () => {
+  window.initMap = initNewPostMap;
+})

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -12,7 +12,8 @@
   <% end %>
   <%= render 'form', {post: @post, action: 'update-post'} %>
 </div>
-<div type="text/javascript">
-  <%= javascript_pack_tag 'map_edit_post', 'data-turbolinks-track': 'reload' %>
+<div>
+  <%= javascript_pack_tag 'map_edit_post', 'data-turbolinks-track': 'reload'%>
+  <%= javascript_pack_tag 'map_common', 'data-turbolinks-track': 'reload', type: "module" %>
   <script src="https://maps.googleapis.com/maps/api/js?language=ja&key=<%= ENV['GOOGLE_MAPS_API_KEY'] %>&callback=initMap" async defer></script>
 </div>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -12,7 +12,7 @@
   <% end %>
   <%= render 'form', {post: @post, action: 'create-post'} %>
 </div>
-<div type="text/javascript">
+<div>
   <%= javascript_pack_tag 'map_new_post', 'data-turbolinks-track': 'reload' %>
   <%= javascript_pack_tag 'map_common', 'data-turbolinks-track': 'reload', type: "module" %>
   <script src="https://maps.googleapis.com/maps/api/js?language=ja&key=<%= ENV['GOOGLE_MAPS_API_KEY'] %>&callback=initMap" async defer></script>


### PR DESCRIPTION
Turbolinkによる不具合と判明。
ページ遷移した際はinitMapを実行。
リロードした際はdocument.addEventListener('turbolinks:load')で再度initMapを実行。