### PR TITLE
[Phase 0][FE] 投稿フォーム・表示の位置精度対応 #116

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -83,9 +83,12 @@ export interface PostPayload {
     genre: string
     region: string
     prefecture: string
+    /** 位置精度（enum の英語キー: exact / approximate / no_location） */
+    location_accuracy: string
     place: string
-    latitude: number | ''
-    longitude: number | ''
+    /** 位置なしでは null（おおまか / 位置なしのクリア・丸めはサーバ側でも強制される） */
+    latitude: number | null
+    longitude: number | null
     /** 投稿に残す写真の signed_id（全量置き換え。含めなかった既存写真は削除される） */
     photo_signed_ids: string[]
   }

--- a/frontend/src/components/MapPicker.vue
+++ b/frontend/src/components/MapPicker.vue
@@ -14,11 +14,14 @@ const props = withDefaults(
     initialLongitude?: number | null
     // 新規投稿では地図の初期位置（現在地）もフォームへ反映する（旧 map_new_post.js の挙動）
     emitInitialLocation?: boolean
+    // 「位置なし」選択時に地図のクリック・検索・現在地を無効化する
+    disabled?: boolean
   }>(),
   {
     initialLatitude: null,
     initialLongitude: null,
-    emitInitialLocation: false
+    emitInitialLocation: false,
+    disabled: false
   }
 )
 const emit = defineEmits<{ 'location-selected': [location: MapLocation] }>()
@@ -146,17 +149,27 @@ function searchLocation() {
     </div>
     <template v-if="mapAvailable">
       <div class="flex gap-2">
-        <Button type="button" id="current_location" variant="outline" @click="moveToCurrentLocation">現在地</Button>
+        <Button type="button" id="current_location" variant="outline" :disabled="disabled" @click="moveToCurrentLocation">現在地</Button>
         <Input
           id="placeSearch"
           v-model="searchWord"
           type="text"
           placeholder="場所を検索"
+          :disabled="disabled"
           @keydown.enter.prevent="searchLocation"
         />
-        <Button type="button" id="search-location-btn" variant="outline" @click="searchLocation">検索</Button>
+        <Button type="button" id="search-location-btn" variant="outline" :disabled="disabled" @click="searchLocation">検索</Button>
       </div>
-      <div id="map" ref="mapElement" class="h-100 w-full rounded-md"></div>
+      <div class="relative">
+        <div id="map" ref="mapElement" class="h-100 w-full rounded-md" :class="{ 'pointer-events-none': disabled }"></div>
+        <!-- overlay で地図を覆い、クリック不可であることを視覚的にも示す -->
+        <div
+          v-if="disabled"
+          class="bg-background/60 text-muted-foreground absolute inset-0 z-10 flex items-center justify-center rounded-md"
+        >
+          位置情報は保存されません
+        </div>
+      </div>
     </template>
     <Alert v-else>
       <AlertDescription>

--- a/frontend/src/components/PostCard.vue
+++ b/frontend/src/components/PostCard.vue
@@ -22,7 +22,13 @@ const flash = useFlashStore()
 
 const isOwner = computed(() => auth.account?.id === props.post.account.id)
 const canModerate = computed(() => isOwner.value || auth.isAdmin)
-const mapImage = computed(() => staticMapUrl(props.post.latitude, props.post.longitude))
+const isApproximate = computed(() => props.post.location_accuracy === 'approximate')
+// 位置なしは地図なし（MapPin フォールバック）。おおまかは丸め座標のため zoom を落として精度誤認を防ぐ
+const mapImage = computed(() =>
+  props.post.latitude != null && props.post.longitude != null
+    ? staticMapUrl(props.post.latitude, props.post.longitude, { zoom: isApproximate.value ? 13 : 16 })
+    : null
+)
 
 // いいねの状態は一覧・詳細で共有する post オブジェクトへ反映する
 function onFavoriteUpdated(state: FavoriteState) {
@@ -82,6 +88,7 @@ async function destroyPost() {
         <Badge>{{ post.genre }}</Badge>
         <Badge>{{ post.region }}</Badge>
         <Badge v-if="post.prefecture">{{ post.prefecture }}</Badge>
+        <Badge v-if="isApproximate" variant="secondary">おおまか</Badge>
       </div>
 
       <!-- 本文は高さを制限し、下端をぼかして「もっと見る」を重ねる -->

--- a/frontend/src/components/PostForm.vue
+++ b/frontend/src/components/PostForm.vue
@@ -34,9 +34,10 @@ interface PostFormState {
   genre: string
   prefecture: string
   region: string
+  location_accuracy: string
   place: string
-  latitude: number | ''
-  longitude: number | ''
+  latitude: number | null
+  longitude: number | null
 }
 
 // 表示中の写真。既存写真（保存済み）と新規アップロード（未確定）を1つのリストで扱い、
@@ -55,9 +56,10 @@ const form = reactive<PostFormState>({
   genre: '',
   prefecture: '',
   region: '',
+  location_accuracy: 'exact',
   place: '',
-  latitude: '',
-  longitude: ''
+  latitude: null,
+  longitude: null
 })
 const photos = ref<PhotoItem[]>([])
 const uploadErrors = ref<string[]>([])
@@ -94,7 +96,8 @@ onMounted(async () => {
     form.genre = props.initialPost.genre
     form.prefecture = props.initialPost.prefecture || ''
     form.region = props.initialPost.region
-    form.place = props.initialPost.place
+    form.location_accuracy = props.initialPost.location_accuracy
+    form.place = props.initialPost.place || ''
     form.latitude = props.initialPost.latitude
     form.longitude = props.initialPost.longitude
     photos.value = props.initialPost.photos.map((photo) => ({
@@ -104,6 +107,19 @@ onMounted(async () => {
     }))
   }
 })
+
+const isNoLocation = computed(() => form.location_accuracy === 'no_location')
+const isApproximate = computed(() => form.location_accuracy === 'approximate')
+
+// 「位置なし」に切り替えたら座標・place をクリアする（都道府県は地域表示に使うため残す）
+function onAccuracyChange(value: string) {
+  form.location_accuracy = value
+  if (value === 'no_location') {
+    form.latitude = null
+    form.longitude = null
+    form.place = ''
+  }
+}
 
 // 地図から位置が選択されたらフォームへ反映（旧 map_common.js の hidden フィールド入力に相当）
 function onLocationSelected(location: MapLocation) {
@@ -166,6 +182,7 @@ function submit() {
       genre: form.genre,
       region: form.region,
       prefecture: form.prefecture,
+      location_accuracy: form.location_accuracy,
       place: form.place,
       latitude: form.latitude,
       longitude: form.longitude,
@@ -205,10 +222,28 @@ defineExpose({ markSaved })
       </div>
     </RadioGroup>
 
+    <div class="space-y-2">
+      <Label>位置精度</Label>
+      <RadioGroup
+        :model-value="form.location_accuracy"
+        class="flex flex-wrap justify-around gap-4"
+        @update:model-value="(v) => onAccuracyChange(String(v ?? 'exact'))"
+      >
+        <div v-for="accuracy in meta.locationAccuracies" :key="accuracy.value" class="flex items-center gap-2">
+          <RadioGroupItem :id="`post_location_accuracy_${accuracy.value}`" :value="accuracy.value" />
+          <Label :for="`post_location_accuracy_${accuracy.value}`" class="font-normal">{{ accuracy.label }}</Label>
+        </div>
+      </RadioGroup>
+      <p v-if="isApproximate" class="text-muted-foreground text-sm">
+        地図のピン位置は約1km単位に丸めて保存・表示されます
+      </p>
+    </div>
+
     <MapPicker
       :initial-latitude="initialPost ? initialPost.latitude : null"
       :initial-longitude="initialPost ? initialPost.longitude : null"
       :emit-initial-location="mode === 'new'"
+      :disabled="isNoLocation"
       @location-selected="onLocationSelected"
     />
 

--- a/frontend/src/stores/meta.ts
+++ b/frontend/src/stores/meta.ts
@@ -8,6 +8,7 @@ export const useMetaStore = defineStore('meta', {
     regions: [] as MetaOption[],
     prefectures: [] as MetaOption[],
     genres: [] as MetaOption[],
+    locationAccuracies: [] as MetaOption<string>[],
     prefectureToRegion: {} as Record<string, string>,
     loaded: false
   }),
@@ -18,6 +19,7 @@ export const useMetaStore = defineStore('meta', {
       this.regions = data.regions
       this.prefectures = data.prefectures
       this.genres = data.genres
+      this.locationAccuracies = data.location_accuracies
       this.prefectureToRegion = data.prefecture_to_region
       this.loaded = true
     }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -49,9 +49,13 @@ export interface Post {
   genre: string
   region: string
   prefecture: string | null
-  place: string
-  latitude: number
-  longitude: number
+  /** おおまか / 位置なしの投稿では null（サーバ側で保存しない） */
+  place: string | null
+  /** 位置なしの投稿では null。おおまかは 0.01 度グリッドに丸め済み */
+  latitude: number | null
+  longitude: number | null
+  /** 位置精度（enum の英語キー: exact / approximate / no_location） */
+  location_accuracy: string
   created_at: string
   account: AccountBasic
   photos: PostPhoto[]
@@ -68,9 +72,9 @@ export interface PaginationMeta {
 }
 
 /** Api::V1::MetaController#show の選択肢（label: 表示名 / value: enum 値） */
-export interface MetaOption {
+export interface MetaOption<V = number> {
   label: string
-  value: number
+  value: V
 }
 
 /** Api::V1::MetaController#show */
@@ -78,6 +82,8 @@ export interface MetaResponse {
   regions: MetaOption[]
   prefectures: MetaOption[]
   genres: MetaOption[]
+  /** 新規 enum は英語キー運用のため value は文字列（例: { label: "正確", value: "exact" }） */
+  location_accuracies: MetaOption<string>[]
   prefecture_to_region: Record<string, string>
 }
 

--- a/frontend/src/utils/googleMaps.ts
+++ b/frontend/src/utils/googleMaps.ts
@@ -42,6 +42,12 @@ export function embedMapUrl(placeId: string, latitude: number, longitude: number
   return `https://www.google.com/maps/embed/v1/place?key=${googleMapsApiKey}&q=place_id:${placeId}&center=${latitude},${longitude}&zoom=${zoom}`
 }
 
+// place_id を持たない「おおまか」投稿用の Embed API（view モード）の iframe URL
+export function embedViewUrl(latitude: number, longitude: number, zoom = 14): string | null {
+  if (!googleMapsApiKey) return null
+  return `https://www.google.com/maps/embed/v1/view?key=${googleMapsApiKey}&center=${latitude},${longitude}&zoom=${zoom}`
+}
+
 // キー無しでも使える Google マップへの外部リンク
 export function googleMapsLinkUrl(latitude: number, longitude: number): string {
   return `https://www.google.com/maps/search/?api=1&query=${latitude},${longitude}`

--- a/frontend/src/views/PostShowView.vue
+++ b/frontend/src/views/PostShowView.vue
@@ -7,7 +7,7 @@ import { Button } from '@/components/ui/button'
 import { useAuthStore } from '../stores/auth'
 import { useFlashStore } from '../stores/flash'
 import { postsApi } from '../api'
-import { embedMapUrl, googleMapsLinkUrl } from '../utils/googleMaps'
+import { embedMapUrl, embedViewUrl, googleMapsLinkUrl } from '../utils/googleMaps'
 import { timeAgoInWords } from '../utils/timeAgo'
 import FavoriteButton from '../components/FavoriteButton.vue'
 import PortraitIcon from '../components/PortraitIcon.vue'
@@ -23,8 +23,20 @@ const post = ref<Post | null>(null)
 
 const isOwner = computed(() => !!post.value && auth.account?.id === post.value.account.id)
 const canModerate = computed(() => isOwner.value || auth.isAdmin)
-const embedUrl = computed(() => (post.value ? embedMapUrl(post.value.place, post.value.latitude, post.value.longitude) : null))
-const externalMapUrl = computed(() => (post.value ? googleMapsLinkUrl(post.value.latitude, post.value.longitude) : ''))
+const isApproximate = computed(() => post.value?.location_accuracy === 'approximate')
+// 位置なし（座標 null）は地図セクション自体を表示しない
+const hasLocation = computed(() => post.value != null && post.value.latitude != null && post.value.longitude != null)
+// おおまかは place_id を持たないため view モード（丸め座標のみ）で表示する
+const embedUrl = computed(() => {
+  if (!post.value || post.value.latitude == null || post.value.longitude == null) return null
+  if (isApproximate.value) return embedViewUrl(post.value.latitude, post.value.longitude)
+  return post.value.place ? embedMapUrl(post.value.place, post.value.latitude, post.value.longitude) : null
+})
+const externalMapUrl = computed(() =>
+  post.value && post.value.latitude != null && post.value.longitude != null
+    ? googleMapsLinkUrl(post.value.latitude, post.value.longitude)
+    : ''
+)
 
 onMounted(async () => {
   const { data } = await postsApi.show(props.id)
@@ -56,6 +68,7 @@ async function destroyPost() {
         <Badge>{{ post.genre }}</Badge>
         <Badge>{{ post.region }}</Badge>
         <Badge v-if="post.prefecture">{{ post.prefecture }}</Badge>
+        <Badge v-if="isApproximate" variant="secondary">おおまか</Badge>
       </div>
       <small class="text-muted-foreground">{{ timeAgoInWords(post.created_at) }}</small>
     </div>
@@ -85,19 +98,24 @@ async function destroyPost() {
       <p class="text-justify wrap-break-word whitespace-pre-wrap">{{ post.description }}</p>
     </div>
 
-    <div v-if="embedUrl" class="relative mb-4 h-[65vh] w-full overflow-hidden rounded-md">
-      <iframe
-        class="absolute inset-0 h-full w-full border-0"
-        referrerpolicy="no-referrer-when-downgrade"
-        :src="embedUrl"
-        allowfullscreen
-      ></iframe>
-    </div>
-    <div v-else class="mb-4">
-      <a :href="externalMapUrl" target="_blank" rel="noopener" class="text-primary inline-flex items-center gap-1 hover:underline">
-        <MapPinIcon class="size-4" /> Google マップで場所を確認する
-      </a>
-    </div>
+    <template v-if="hasLocation">
+      <p v-if="isApproximate" class="text-muted-foreground mb-2 text-sm">
+        位置情報は約1km単位に丸めて表示しています
+      </p>
+      <div v-if="embedUrl" class="relative mb-4 h-[65vh] w-full overflow-hidden rounded-md">
+        <iframe
+          class="absolute inset-0 h-full w-full border-0"
+          referrerpolicy="no-referrer-when-downgrade"
+          :src="embedUrl"
+          allowfullscreen
+        ></iframe>
+      </div>
+      <div v-else class="mb-4">
+        <a :href="externalMapUrl" target="_blank" rel="noopener" class="text-primary inline-flex items-center gap-1 hover:underline">
+          <MapPinIcon class="size-4" /> Google マップで場所を確認する
+        </a>
+      </div>
+    </template>
 
     <div class="flex justify-evenly">
       <template v-if="canModerate">


### PR DESCRIPTION
Closes #116(Parent: #104、依存: #113 = PR #121)
仕様: [docs/design/issue104-phase0-location-privacy-and-trust.md](https://github.com/Mottttton/yaeh_map/blob/main/docs/design/issue104-phase0-location-privacy-and-trust.md) §1.5

> **Note**: ベースブランチは `feature/113-location-accuracy-be`(PR #121)。#121 マージ後に main へ向け直すか、そのままスタックでマージしてください。

## 変更内容
- `types/index.ts`: `Post` の `latitude` / `longitude` / `place` を null 許容化、`location_accuracy: string` 追加。`MetaOption` をジェネリクス化(`MetaOption<V = number>`)し `MetaResponse.location_accuracies: MetaOption<string>[]` を追加
- `api/index.ts`: `PostPayload` に `location_accuracy` 追加、座標を `number | null` に
- `stores/meta.ts`: `locationAccuracies` を保持
- `PostForm.vue`: 位置精度 RadioGroup(genre と同型、meta から生成)を MapPicker 直上に追加。「位置なし」で座標・place をクリアし MapPicker を無効化、「おおまか」で「約1km単位に丸めて保存・表示されます」の注意文言。都道府県 select は手動選択可のまま(位置なし投稿の地域決定手段)
- `MapPicker.vue`: `disabled` prop 追加。overlay(「位置情報は保存されません」)+ `pointer-events-none` で地図クリックを、`disabled` 属性で検索・現在地を無効化
- `PostCard.vue`: 地図画像を座標 null ガード付きに(位置なしは既存 MapPin フォールバック)。おおまかは zoom 16→13 に落とし「おおまか」Badge
- `PostShowView.vue`: 位置なし → 地図セクション非表示。おおまか → 新設の `embedViewUrl(lat, lng, zoom)`(place_id 不要の view モード)で丸め座標を表示+注意文言+「おおまか」Badge

## 検証
- `vue-tsc --noEmit`: エラーなし
- puppeteer によるスモークテスト(dev 環境): ログイン → 投稿フォームで以下を確認
  - 位置精度 RadioGroup が 3 択(正確 / おおまか / 位置なし)で表示される
  - おおまか選択で丸め注意文言が表示される
  - 位置なし選択で地図に overlay がかかり、検索・現在地ボタンが無効化される
- meta API(`/api/v1/meta`)が `location_accuracies` を配信することを確認

## 受け入れ条件の確認
- [x] 3 精度すべてで投稿・再編集できる(丸め・クリアはサーバ側でも強制)
- [x] 位置なし選択で地図 UI が無効化され、カード・詳細は地図なし表示(フィードには表示される)
- [x] おおまか投稿の再編集で座標が変わらない(BE のグリッドスナップが冪等)
- [x] おおまか投稿のカード・詳細で丸め座標の地図と「おおまか」表示が出る

🤖 Generated with [Claude Code](https://claude.com/claude-code)
